### PR TITLE
Add banner text for PIL requirement

### DIFF
--- a/examples/bonnet_buttons.py
+++ b/examples/bonnet_buttons.py
@@ -19,6 +19,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# This example is for use on (Linux) computers that are using CPython with
+# Adafruit Blinka to support CircuitPython libraries. CircuitPython does
+# not support PIL/pillow (python imaging library)!
+
 import board
 import busio
 from digitalio import DigitalInOut, Direction, Pull

--- a/examples/pillow_animate.py
+++ b/examples/pillow_animate.py
@@ -19,6 +19,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# This example is for use on (Linux) computers that are using CPython with
+# Adafruit Blinka to support CircuitPython libraries. CircuitPython does
+# not support PIL/pillow (python imaging library)!
+
 import math
 import time
 from board import SCL, SDA

--- a/examples/pillow_images.py
+++ b/examples/pillow_images.py
@@ -19,6 +19,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# This example is for use on (Linux) computers that are using CPython with
+# Adafruit Blinka to support CircuitPython libraries. CircuitPython does
+# not support PIL/pillow (python imaging library)!
+
 from board import SCL, SDA
 import busio
 from PIL import Image

--- a/examples/pillow_shapes.py
+++ b/examples/pillow_shapes.py
@@ -19,6 +19,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# This example is for use on (Linux) computers that are using CPython with
+# Adafruit Blinka to support CircuitPython libraries. CircuitPython does
+# not support PIL/pillow (python imaging library)!
+
 from board import SCL, SDA
 import busio
 from PIL import Image, ImageDraw, ImageFont


### PR DESCRIPTION
Adds banner text to examples that use PIL (Pillow) indicating requirement for Linux / CPython.