### PR TITLE
add power property to _SSD1306

### DIFF
--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -84,6 +84,7 @@ class _SSD1306(framebuf.FrameBuffer):
 
     @property
     def power(self):
+	"""True if the display is currently powered on, otherwise False"""
         return self._power
 
     def init_display(self):

--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -240,4 +240,3 @@ class SSD1306_SPI(_SSD1306):
         self.dc_pin.value = 1
         with self.spi_device as spi:
             spi.write(self.buffer)
-

--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -78,8 +78,13 @@ class _SSD1306(framebuf.FrameBuffer):
         # Note the subclass must initialize self.framebuf to a framebuffer.
         # This is necessary because the underlying data buffer is different
         # between I2C and SPI implementations (I2C needs an extra byte).
+        self._power = False
         self.poweron()
         self.init_display()
+
+    @property
+    def power(self):
+        return self._power
 
     def init_display(self):
         """Base class to initialize display"""
@@ -112,6 +117,7 @@ class _SSD1306(framebuf.FrameBuffer):
     def poweroff(self):
         """Turn off the display (nothing visible)"""
         self.write_cmd(SET_DISP | 0x00)
+        self._power = False
 
     def contrast(self, contrast):
         """Adjust the contrast"""
@@ -140,6 +146,7 @@ class _SSD1306(framebuf.FrameBuffer):
             self.reset_pin.value = 1
             time.sleep(0.010)
         self.write_cmd(SET_DISP | 0x01)
+        self._power = True
 
     def show(self):
         """Update the display"""
@@ -232,3 +239,4 @@ class SSD1306_SPI(_SSD1306):
         self.dc_pin.value = 1
         with self.spi_device as spi:
             spi.write(self.buffer)
+

--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -84,7 +84,7 @@ class _SSD1306(framebuf.FrameBuffer):
 
     @property
     def power(self):
-	"""True if the display is currently powered on, otherwise False"""
+        """True if the display is currently powered on, otherwise False"""
         return self._power
 
     def init_display(self):


### PR DESCRIPTION
In an application it is nice to know if the display is on or off.  This is especially true in situations where the display is turned off after an idle period.  This change implements a "power" property which indicates whether the display is currently powered on.