### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -41,7 +41,6 @@ except ImportError:
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_SSD1306.git"
 
-# pylint: disable-msg=bad-whitespace
 # register definitions
 SET_CONTRAST = const(0x81)
 SET_ENTIRE_ON = const(0xA4)
@@ -60,7 +59,6 @@ SET_DISP_CLK_DIV = const(0xD5)
 SET_PRECHARGE = const(0xD9)
 SET_VCOM_DESEL = const(0xDB)
 SET_CHARGE_PUMP = const(0x8D)
-# pylint: enable-msg=bad-whitespace
 
 
 class _SSD1306(framebuf.FrameBuffer):


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.