### PR TITLE
Fix SPI class with new page addressing mode option

### DIFF
--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -291,7 +291,8 @@ class SSD1306_SPI(_SSD1306):
         phase=0,
         page_addressing=False
     ):
-        if page_addressing:
+        self.page_addressing = page_addressing
+        if self.page_addressing:
             raise NotImplementedError(
                 "Page addressing mode with SPI has not yet been implemented."
             )


### PR DESCRIPTION
This small change fixes #58.
The SPI class was missing a page_addressing parameter, which is needed before the super call and use of the base _SSD1306 class.  Thanks @dattrax for the testing and suggested fix.  I agree this is the appropriate solution. Cheers!