### PR TITLE
fixing issue on reading cpu load when decimal separator is not a dot

### DIFF
--- a/examples/ssd1306_stats.py
+++ b/examples/ssd1306_stats.py
@@ -65,7 +65,7 @@ while True:
     # https://unix.stackexchange.com/questions/119126/command-to-display-memory-usage-disk-usage-and-cpu-load
     cmd = "hostname -I | cut -d' ' -f1"
     IP = subprocess.check_output(cmd, shell=True).decode("utf-8")
-    cmd = "top -bn1 | grep load | awk '{printf \"CPU Load: %.2f\", $(NF-2)}'"
+    cmd = "cut -f 1 -d \" \" /proc/loadavg"
     CPU = subprocess.check_output(cmd, shell=True).decode("utf-8")
     cmd = "free -m | awk 'NR==2{printf \"Mem: %s/%s MB  %.2f%%\", $3,$2,$3*100/$2 }'"
     MemUsage = subprocess.check_output(cmd, shell=True).decode("utf-8")
@@ -75,7 +75,7 @@ while True:
     # Write four lines of text.
 
     draw.text((x, top + 0), "IP: " + IP, font=font, fill=255)
-    draw.text((x, top + 8), CPU, font=font, fill=255)
+    draw.text((x, top + 8), "CPU load: " + CPU, font=font, fill=255)
     draw.text((x, top + 16), MemUsage, font=font, fill=255)
     draw.text((x, top + 25), Disk, font=font, fill=255)
 

--- a/examples/ssd1306_stats.py
+++ b/examples/ssd1306_stats.py
@@ -65,7 +65,7 @@ while True:
     # https://unix.stackexchange.com/questions/119126/command-to-display-memory-usage-disk-usage-and-cpu-load
     cmd = "hostname -I | cut -d' ' -f1"
     IP = subprocess.check_output(cmd, shell=True).decode("utf-8")
-    cmd = "cut -f 1 -d \" \" /proc/loadavg"
+    cmd = 'cut -f 1 -d " " /proc/loadavg'
     CPU = subprocess.check_output(cmd, shell=True).decode("utf-8")
     cmd = "free -m | awk 'NR==2{printf \"Mem: %s/%s MB  %.2f%%\", $3,$2,$3*100/$2 }'"
     MemUsage = subprocess.check_output(cmd, shell=True).decode("utf-8")


### PR DESCRIPTION
On a system where the decimal separator is not a dot, the previous command to grab CPU load was failing (e.g. with French locale, the decimal separator is a comma).
My proposal is to read the CPU load from /proc/loadavg instead of querying with top|grep|awk