### PR TITLE
Cleanly request i2c_device with page addressing

### DIFF
--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -255,7 +255,8 @@ class SSD1306_I2C(_SSD1306):
                 self.pagebuffer[1:] = self.buffer[
                     1 + self.width * page : 1 + self.width * (page + 1)
                 ]
-                self.i2c_device.write(self.pagebuffer)
+                with self.i2c_device:
+                    self.i2c_device.write(self.pagebuffer)
         else:
             with self.i2c_device:
                 self.i2c_device.write(self.buffer)


### PR DESCRIPTION
Fixes the locking error reported in #40.