### PR TITLE
Add example to clear the screen

### DIFF
--- a/examples/ssd1306_clear.py
+++ b/examples/ssd1306_clear.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Tony DiCola
+# SPDX-License-Identifier: CC0-1.0
+
+# Basic example of clearing and drawing pixels on a SSD1306 OLED display.
+# This example and library is meant to work with Adafruit CircuitPython API.
+
+# Import all board pins.
+from board import SCL, SDA
+import busio
+
+# Import the SSD1306 module.
+import adafruit_ssd1306
+
+
+# Create the I2C interface.
+i2c = busio.I2C(SCL, SDA)
+
+# Create the SSD1306 OLED class.
+# The first two parameters are the pixel width and pixel height.  Change these
+# to the right size for your display!
+display = adafruit_ssd1306.SSD1306_I2C(128, 32, i2c)
+# Alternatively you can change the I2C address of the device with an addr parameter:
+# display = adafruit_ssd1306.SSD1306_I2C(128, 32, i2c, addr=0x31)
+
+# Clear the display.  Always call show after changing pixels to make the display
+# update visible!
+display.fill(0)
+display.show()


### PR DESCRIPTION
I thought this was useful since the product page talks about keeping the pixels off when possible. Also, whether prototyping or scripting, it's nice to get able to get rid of out-of-date content.