### PR TITLE
Fix compatibility with MicroPython

### DIFF
--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -17,9 +17,15 @@ from micropython import const
 from adafruit_bus_device import i2c_device, spi_device
 
 try:
+    # MicroPython framebuf import
     import framebuf
+
+    _FRAMEBUF_FORMAT = framebuf.MONO_VLSB
 except ImportError:
+    # CircuitPython framebuf import
     import adafruit_framebuf as framebuf
+
+    _FRAMEBUF_FORMAT = framebuf.MVLSB
 
 try:
     # Used only for typing
@@ -67,7 +73,7 @@ class _SSD1306(framebuf.FrameBuffer):
         reset: Optional[digitalio.DigitalInOut],
         page_addressing: bool
     ):
-        super().__init__(buffer, width, height)
+        super().__init__(buffer, width, height, _FRAMEBUF_FORMAT)
         self.width = width
         self.height = height
         self.external_vcc = external_vcc


### PR DESCRIPTION
Fixes #77 which is caused by the fact that the format must be specified for MicroPython, but not CircuitPython.

Links to docs for reference:
[MicroPython `framebuf.FrameBuffer`](https://docs.micropython.org/en/latest/library/framebuf.html#framebuf.FrameBuffer)
[CircuitPython `adafruit_framebuf.FrameBuffer`](https://docs.circuitpython.org/projects/framebuf/en/latest/api.html#adafruit_framebuf.FrameBuffer)