### PR TITLE
Update simpletest with 8.0 standards

### DIFF
--- a/examples/ssd1306_simpletest.py
+++ b/examples/ssd1306_simpletest.py
@@ -4,26 +4,26 @@
 # Basic example of clearing and drawing pixels on a SSD1306 OLED display.
 # This example and library is meant to work with Adafruit CircuitPython API.
 
-# Import all board pins.
-from board import SCL, SDA
+import time
+import board
 import busio
-
-# Import the SSD1306 module.
+import displayio
 import adafruit_ssd1306
 
+displayio.release_displays()
 
-# Create the I2C interface.
-i2c = busio.I2C(SCL, SDA)
+# Create the I2C bus interface.
+i2c = board.I2C()  # uses board.SCL and board.SDA
+# i2c = busio.I2C(board.GP1, board.GP0)    # Pi Pico RP2040
 
 # Create the SSD1306 OLED class.
-# The first two parameters are the pixel width and pixel height.  Change these
-# to the right size for your display!
-display = adafruit_ssd1306.SSD1306_I2C(128, 32, i2c)
-# Alternatively you can change the I2C address of the device with an addr parameter:
-# display = adafruit_ssd1306.SSD1306_I2C(128, 32, i2c, addr=0x31)
+display_width = 128
+display_height = 32
+display = adafruit_ssd1306.SSD1306_I2C(display_width, display_height, i2c)
+# You can change the I2C address with an addr parameter:
+# display = adafruit_ssd1306.SSD1306_I2C(display_width, display_height, i2c, addr=0x31)
 
-# Clear the display.  Always call show after changing pixels to make the display
-# update visible!
+# fills display with black pixels clearing it
 display.fill(0)
 display.show()
 

--- a/examples/ssd1306_simpletest.py
+++ b/examples/ssd1306_simpletest.py
@@ -4,7 +4,6 @@
 # Basic example of clearing and drawing pixels on a SSD1306 OLED display.
 # This example and library is meant to work with Adafruit CircuitPython API.
 
-import time
 import board
 import busio
 import displayio

--- a/examples/ssd1306_simpletest.py
+++ b/examples/ssd1306_simpletest.py
@@ -5,7 +5,6 @@
 # This example and library is meant to work with Adafruit CircuitPython API.
 
 import board
-import busio
 import displayio
 import adafruit_ssd1306
 


### PR DESCRIPTION
Includes displayio initiatlization missing from outdated example. This was an issue dealing with support questions related to missing displayio import. Also added height and width ints to make it easier for beginners to change screen sizes as these OLED displays come in a variety of sizes now.