### PR TITLE
Don't import Micropython framebuf in Circuitpython

### DIFF
--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -13,15 +13,16 @@ MicroPython SSD1306 OLED driver, I2C and SPI interfaces
 
 import time
 
+from sys import implementation
 from micropython import const
 from adafruit_bus_device import i2c_device, spi_device
 
-try:
+if implementation.name.upper() == "MICROPYTHON":
     # MicroPython framebuf import
     import framebuf
 
     _FRAMEBUF_FORMAT = framebuf.MONO_VLSB
-except ImportError:
+elif implementation.name.upper() == "CIRCUITPYTHON":
     # CircuitPython framebuf import
     import adafruit_framebuf as framebuf
 

--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -17,11 +17,17 @@ from sys import implementation
 from micropython import const
 from adafruit_bus_device import i2c_device, spi_device
 
-if implementation.name.upper() == "MICROPYTHON":
-    # MicroPython framebuf import
-    import framebuf
+if implementation.name.upper() == "CPYTHON":
+    try:
+        # MicroPython framebuf import
+        import framebuf
 
-    _FRAMEBUF_FORMAT = framebuf.MONO_VLSB
+        _FRAMEBUF_FORMAT = framebuf.MONO_VLSB
+    except:
+        # CircuitPython framebuf import
+        import adafruit_framebuf as framebuf
+
+        _FRAMEBUF_FORMAT = framebuf.MVLSB
 else:
     # CircuitPython framebuf import
     import adafruit_framebuf as framebuf

--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -17,22 +17,27 @@ from sys import implementation
 from micropython import const
 from adafruit_bus_device import i2c_device, spi_device
 
-if implementation.name.upper() == "CPYTHON":
-    try:
-        # MicroPython framebuf import
-        import framebuf
-
-        _FRAMEBUF_FORMAT = framebuf.MONO_VLSB
-    except:
-        # CircuitPython framebuf import
-        import adafruit_framebuf as framebuf
-
-        _FRAMEBUF_FORMAT = framebuf.MVLSB
-else:
+if implementation.name.upper() == "CIRCUITPYTHON":
     # CircuitPython framebuf import
     import adafruit_framebuf as framebuf
 
     _FRAMEBUF_FORMAT = framebuf.MVLSB
+elif implementation.name.upper() == "MICROPYTHON":
+    # MicroPython framebuf import
+    import framebuf
+
+    _FRAMEBUF_FORMAT = framebuf.MONO_VLSB
+elif implementation.name.upper() == "CPYTHON":
+    try:
+        # CircuitPython framebuf import
+        import adafruit_framebuf as framebuf
+
+        _FRAMEBUF_FORMAT = framebuf.MVLSB
+    except ImportError:
+        # MicroPython framebuf import
+        import framebuf
+
+        _FRAMEBUF_FORMAT = framebuf.MONO_VLSB
 
 try:
     # Used only for typing

--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -22,7 +22,7 @@ if implementation.name.upper() == "MICROPYTHON":
     import framebuf
 
     _FRAMEBUF_FORMAT = framebuf.MONO_VLSB
-elif implementation.name.upper() == "CIRCUITPYTHON":
+else:
     # CircuitPython framebuf import
     import adafruit_framebuf as framebuf
 

--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -17,25 +17,16 @@ from sys import implementation
 from micropython import const
 from adafruit_bus_device import i2c_device, spi_device
 
-if (
-    implementation.name.upper() == "CIRCUITPYTHON"
-    or implementation.name.upper() == "CPYTHON"
-):
-    try:
-        # CircuitPython framebuf import
-        import adafruit_framebuf as framebuf
-
-        _FRAMEBUF_FORMAT = framebuf.MVLSB
-    except ImportError as exc:
-        if implementation.name.upper() == "CIRCUITPYTHON":
-            raise ImportError("no module named adafruit_framebuf") from exc
-
-# If framebuf wasn't imported then we must be running under CPYTHON or MICROPYTHON
-if not "framebuf" in dir():
+if implementation.name.upper() == "MICROPYTHON":
     # MicroPython framebuf import
     import framebuf
 
     _FRAMEBUF_FORMAT = framebuf.MONO_VLSB
+else:
+    # CircuitPython framebuf import
+    import adafruit_framebuf as framebuf
+
+    _FRAMEBUF_FORMAT = framebuf.MVLSB
 
 try:
     # Used only for typing

--- a/adafruit_ssd1306.py
+++ b/adafruit_ssd1306.py
@@ -17,27 +17,25 @@ from sys import implementation
 from micropython import const
 from adafruit_bus_device import i2c_device, spi_device
 
-if implementation.name.upper() == "CIRCUITPYTHON":
-    # CircuitPython framebuf import
-    import adafruit_framebuf as framebuf
-
-    _FRAMEBUF_FORMAT = framebuf.MVLSB
-elif implementation.name.upper() == "MICROPYTHON":
-    # MicroPython framebuf import
-    import framebuf
-
-    _FRAMEBUF_FORMAT = framebuf.MONO_VLSB
-elif implementation.name.upper() == "CPYTHON":
+if (
+    implementation.name.upper() == "CIRCUITPYTHON"
+    or implementation.name.upper() == "CPYTHON"
+):
     try:
         # CircuitPython framebuf import
         import adafruit_framebuf as framebuf
 
         _FRAMEBUF_FORMAT = framebuf.MVLSB
-    except ImportError:
-        # MicroPython framebuf import
-        import framebuf
+    except ImportError as exc:
+        if implementation.name.upper() == "CIRCUITPYTHON":
+            raise ImportError("no module named adafruit_framebuf") from exc
 
-        _FRAMEBUF_FORMAT = framebuf.MONO_VLSB
+# If framebuf wasn't imported then we must be running under CPYTHON or MICROPYTHON
+if not "framebuf" in dir():
+    # MicroPython framebuf import
+    import framebuf
+
+    _FRAMEBUF_FORMAT = framebuf.MONO_VLSB
 
 try:
     # Used only for typing


### PR DESCRIPTION
fixes #83 

I suspect the import of framebuf.mpy was intended to allow this library to be used in Micropython, not for the Micropython version of framebuf.mpy to be used in Circuitpython.