### PR TITLE
Fix Pillow 10 errors when running example files

### DIFF
--- a/examples/ssd1306_pillow_animate.py
+++ b/examples/ssd1306_pillow_animate.py
@@ -74,7 +74,7 @@ while True:
             break
         # Calculate width but skip drawing if off the left side of screen.
         if x < -10:
-            bbox = draw.textbbox((0,0), c, font=font)
+            bbox = draw.textbbox((0, 0), c, font=font)
             char_width, char_height = bbox[2] - bbox[0], bbox[3] - bbox[1]
             x += char_width
             continue
@@ -83,7 +83,7 @@ while True:
         # Draw text.
         draw.text((x, y), c, font=font, fill=255)
         # Increment x position based on chacacter width.
-        bbox = draw.textbbox((0,0), c, font=font)
+        bbox = draw.textbbox((0, 0), c, font=font)
         char_width, char_height = bbox[2] - bbox[0], bbox[3] - bbox[1]
         x += char_width
 

--- a/examples/ssd1306_pillow_animate.py
+++ b/examples/ssd1306_pillow_animate.py
@@ -51,7 +51,8 @@ text = (
     "SSD1306 ORGANIC LED DISPLAY. THIS IS AN OLD SCHOOL DEMO SCROLLER!!"
     + "GREETZ TO: LADYADA & THE ADAFRUIT CREW, TRIXTER, FUTURE CREW, AND FARBRAUSCH"
 )
-maxwidth, unused = draw.textsize(text, font=font)
+bbox = draw.textbbox((0,0), text, font=font)
+maxwidth = bbox[2] - bbox[0]
 
 # Set animation and sine wave parameters.
 amplitude = height / 4
@@ -73,7 +74,8 @@ while True:
             break
         # Calculate width but skip drawing if off the left side of screen.
         if x < -10:
-            char_width, char_height = draw.textsize(c, font=font)
+            bbox = draw.textbbox((0,0), c, font=font)
+            char_width, char_height = bbox[2] - bbox[0], bbox[3] - bbox[1]
             x += char_width
             continue
         # Calculate offset from sine wave.
@@ -81,7 +83,8 @@ while True:
         # Draw text.
         draw.text((x, y), c, font=font, fill=255)
         # Increment x position based on chacacter width.
-        char_width, char_height = draw.textsize(c, font=font)
+        bbox = draw.textbbox((0,0), c, font=font)
+        char_width, char_height = bbox[2] - bbox[0], bbox[3] - bbox[1]
         x += char_width
 
     # Draw the image buffer.

--- a/examples/ssd1306_pillow_animate.py
+++ b/examples/ssd1306_pillow_animate.py
@@ -51,7 +51,7 @@ text = (
     "SSD1306 ORGANIC LED DISPLAY. THIS IS AN OLD SCHOOL DEMO SCROLLER!!"
     + "GREETZ TO: LADYADA & THE ADAFRUIT CREW, TRIXTER, FUTURE CREW, AND FARBRAUSCH"
 )
-bbox = draw.textbbox((0,0), text, font=font)
+bbox = draw.textbbox((0, 0), text, font=font)
 maxwidth = bbox[2] - bbox[0]
 
 # Set animation and sine wave parameters.

--- a/examples/ssd1306_pillow_clock.py
+++ b/examples/ssd1306_pillow_clock.py
@@ -20,7 +20,14 @@ RESET_PIN = digitalio.DigitalInOut(board.D4)
 
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-oled = adafruit_ssd1306.SSD1306_I2C(128, 64, i2c, addr=0x3D, reset=RESET_PIN)
+
+# Create the SSD1306 OLED class.
+# The first two parameters are the pixel width and pixel height.
+# Change these to the right size for your display!
+oled = adafruit_ssd1306.SSD1306_I2C(128, 64, i2c)
+
+# Note you can change the I2C address, or add a reset pin:
+# oled = adafruit_ssd1306.SSD1306_I2C(128, 64, i2c, addr=0x3D, reset=RESET_PIN)
 
 # Clear display.
 oled.fill(0)

--- a/examples/ssd1306_pillow_demo.py
+++ b/examples/ssd1306_pillow_demo.py
@@ -61,7 +61,8 @@ font = ImageFont.load_default()
 
 # Draw Some Text
 text = "Hello World!"
-(font_width, font_height) = font.getsize(text)
+bbox = font.getbbox(text)
+(font_width, font_height) = bbox[2] - bbox[0], bbox[3] - bbox[1]
 draw.text(
     (oled.width // 2 - font_width // 2, oled.height // 2 - font_height // 2),
     text,

--- a/examples/ssd1306_pillow_image_display.py
+++ b/examples/ssd1306_pillow_image_display.py
@@ -20,7 +20,14 @@ RESET_PIN = digitalio.DigitalInOut(board.D4)
 
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-oled = adafruit_ssd1306.SSD1306_I2C(128, 64, i2c, addr=0x3D, reset=RESET_PIN)
+
+# Create the SSD1306 OLED class.
+# The first two parameters are the pixel width and pixel height.
+# Change these to the right size for your display!
+oled = adafruit_ssd1306.SSD1306_I2C(128, 64, i2c)
+
+# Note you can change the I2C address, or add a reset pin:
+# oled = adafruit_ssd1306.SSD1306_I2C(128, 64, i2c, addr=0x3D, reset=RESET_PIN)
 
 # Clear display.
 oled.fill(0)

--- a/examples/ssd1306_pillow_ip.py
+++ b/examples/ssd1306_pillow_ip.py
@@ -37,7 +37,14 @@ TEXT = ""
 # Very important... This lets py-gaugette 'know' what pins to use in order to reset the display
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-oled = adafruit_ssd1306.SSD1306_I2C(128, 64, i2c, addr=0x3D, reset=RESET_PIN)
+
+# Create the SSD1306 OLED class.
+# The first two parameters are the pixel width and pixel height.
+# Change these to the right size for your display!
+oled = adafruit_ssd1306.SSD1306_I2C(128, 64, i2c)
+
+# Note you can change the I2C address, or add a reset pin:
+# oled = adafruit_ssd1306.SSD1306_I2C(128, 64, i2c, addr=0x3D, reset=RESET_PIN)
 
 # This sets TEXT equal to whatever your IP address is, or isn't
 try:

--- a/examples/ssd1306_pillow_text.py
+++ b/examples/ssd1306_pillow_text.py
@@ -20,7 +20,14 @@ RESET_PIN = digitalio.DigitalInOut(board.D4)
 # Very important... This lets py-gaugette 'know' what pins to use in order to reset the display
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-oled = adafruit_ssd1306.SSD1306_I2C(128, 64, i2c, addr=0x3D, reset=RESET_PIN)
+
+# Create the SSD1306 OLED class.
+# The first two parameters are the pixel width and pixel height.
+# Change these to the right size for your display!
+oled = adafruit_ssd1306.SSD1306_I2C(128, 64, i2c)
+
+# Note you can change the I2C address, or add a reset pin:
+# oled = adafruit_ssd1306.SSD1306_I2C(128, 64, i2c, addr=0x3D, reset=RESET_PIN)
 
 # Clear display.
 oled.fill(0)

--- a/examples/ssd1306_simpletest.py
+++ b/examples/ssd1306_simpletest.py
@@ -5,10 +5,7 @@
 # This example and library is meant to work with Adafruit CircuitPython API.
 
 import board
-import displayio
 import adafruit_ssd1306
-
-displayio.release_displays()
 
 # Create the I2C bus interface.
 i2c = board.I2C()  # uses board.SCL and board.SDA


### PR DESCRIPTION
This pull request will update several of the example files to work with the latest version of Pillow 10.2.0.

The `textsize` and `getsize` functions used in several example files in this repo were deprecated in Pillow 9.5.0 and [removed in 10.0.0](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#font-size-and-offset-methods).